### PR TITLE
De 651 enps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# IDE
+.idea/

--- a/tap_bamboohr/schemas/enps.json
+++ b/tap_bamboohr/schemas/enps.json
@@ -1,0 +1,62 @@
+{
+  "type": ["object"],
+  "properties": {
+    "report_id": {
+      "type": ["integer", "null"]
+    },
+    "title": {
+      "type": ["string", "null"]
+    },
+    "score": {
+      "type": ["integer", "null"]
+    },
+    "number_of_promoters": {
+      "type": ["integer", "null"]
+    },
+    "number_of_neutrals": {
+      "type": ["integer", "null"]
+    },
+    "number_of_detractors": {
+      "type": ["integer", "null"]
+    },
+    "number_of_responses": {
+      "type": ["integer", "null"]
+    },
+    "response_rate_percent": {
+      "type": ["string", "null"]
+    },
+    "response_rate_description": {
+      "type": ["string", "null"]
+    },
+    "has_enough_data": {
+      "type": ["boolean", "null"]
+    },
+    "survey_open": {
+      "type": ["boolean", "null"]
+    },
+    "survey_close_date": {
+      "type": ["string", "null"]
+    },
+    "survey_percent_complete": {
+      "type": ["integer", "null"]
+    },
+    "survey_filter_value": {
+      "type": ["string", "null"]
+    },
+    "survey_filter_label": {
+      "type": ["string", "null"]
+    },
+    "trend_dates": {
+      "type": ["string", "null"]
+    },
+    "trend_scores": {
+      "type": ["string", "null"]
+    },
+    "department_scores": {
+      "type": ["string", "null"]
+    },
+    "division_scores": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/tap_bamboohr/schemas/enps_surveys.json
+++ b/tap_bamboohr/schemas/enps_surveys.json
@@ -1,0 +1,11 @@
+{
+  "type": ["object"],
+  "properties": {
+    "survey_id": {
+      "type": ["string"]
+    },
+    "survey_label": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/tap_bamboohr/schemas/jobs.json
+++ b/tap_bamboohr/schemas/jobs.json
@@ -1,0 +1,50 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "object"
+    },
+    "postedDate": {
+      "type": "string"
+    },
+    "location": {
+      "type": "object"
+    },
+    "department": {
+      "type": "object"
+    },
+    "status": {
+      "type": "object"
+    },
+    "hiringLead": {
+      "type": "object"
+    },
+    "newApplicantsCount": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "activeApplicantsCount": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "totalApplicantsCount": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "postingUrl": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
+}

--- a/tap_bamboohr/streams.py
+++ b/tap_bamboohr/streams.py
@@ -505,3 +505,11 @@ class TimeOffRequests(TapBambooHRStream):
             "start": "1900-01-01",
             "end": "2100-12-12"
         }  # We want all of the data; these should be far enough in the future/past
+
+class Jobs(TapBambooHRStream):
+    name = "jobs"
+    path = "/applicant_tracking/jobs?statusGroups=ALL"
+    primary_keys = ["id"]
+    records_jsonpath = "$[*]"
+    replication_key = None
+    schema_filepath = SCHEMAS_DIR / "jobs.json"

--- a/tap_bamboohr/streams.py
+++ b/tap_bamboohr/streams.py
@@ -475,6 +475,104 @@ class JobInfo(TapBambooHRStream):
                 yield row
 
 
+class ENPS(TapBambooHRStream):
+    """Employee Net Promoter Score report stream.
+
+    Uses the subdomain-based URL (not the API gateway).
+    Extracts key eNPS metrics from the widget-based report response.
+    """
+
+    name = "enps"
+    path = "/reports/enps/-49"
+    primary_keys = ["report_id", "survey_filter_value"]
+    replication_key = None
+    schema_filepath = SCHEMAS_DIR / "enps.json"
+
+    @property
+    def url_base(self) -> str:
+        subdomain = self.config.get("subdomain")
+        return f"https://{subdomain}.bamboohr.com"
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        return {"format": "json"}
+
+    def get_new_paginator(self) -> SinglePagePaginator:
+        return SinglePagePaginator()
+
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:
+        data = response.json()
+        format_data = data.get("formatData", {})
+        widgets = format_data.get("widgets", {})
+
+        # eNPS score from radial chart widget
+        radial = widgets.get("enpsScoreRadialChart", {}).get("data", {})
+        # Trend chart widget
+        trend = widgets.get("enpsTrendChart", {}).get("data", {})
+        # Survey status widget
+        survey_open_data = widgets.get("surveyOpen", {}).get("data", {})
+        # Survey filter widget (which survey period)
+        survey_filter = widgets.get("surveyFilter", {}).get("data", {})
+        # Scores across company widget
+        across_company = widgets.get("scoresAcrossCompanyChart", {}).get("data", {})
+
+        # Find selected survey filter
+        survey_filter_value = None
+        survey_filter_label = None
+        for item in survey_filter.get("selectData", {}).get("items", []):
+            if item.get("selected"):
+                survey_filter_value = item.get("value")
+                survey_filter_label = item.get("displayText")
+                break
+
+        # Extract department scores (left chart)
+        dept_scores = None
+        left_chart = across_company.get("charts", {}).get("left", {})
+        if left_chart.get("bars"):
+            dept_scores = json.dumps(left_chart["bars"])
+
+        # Extract division scores (right chart)
+        div_scores = None
+        right_chart = across_company.get("charts", {}).get("right", {})
+        if right_chart.get("bars"):
+            div_scores = json.dumps(right_chart["bars"])
+
+        # Extract trend data
+        trend_dates = None
+        trend_scores = None
+        if trend.get("xAxisTitles"):
+            trend_dates = json.dumps(trend["xAxisTitles"])
+        if trend.get("lines") and len(trend["lines"]) > 0:
+            points = trend["lines"][0].get("points", [])
+            trend_scores = json.dumps([p.get("y") for p in points])
+
+        record = {
+            "report_id": format_data.get("reportId"),
+            "title": data.get("title"),
+            "score": radial.get("mainBar", {}).get("value"),
+            "number_of_promoters": radial.get("numberOfPromoters"),
+            "number_of_neutrals": radial.get("numberOfNeutrals"),
+            "number_of_detractors": radial.get("numberOfDetractors"),
+            "number_of_responses": radial.get("numberOfResponses"),
+            "response_rate_percent": radial.get("ternaryPercent"),
+            "response_rate_description": radial.get("ternaryValue"),
+            "has_enough_data": widgets.get("enpsScoreRadialChart", {}).get(
+                "hasEnoughData"
+            ),
+            "survey_open": survey_open_data.get("open"),
+            "survey_close_date": survey_open_data.get("closeDate"),
+            "survey_percent_complete": survey_open_data.get("percentComplete"),
+            "survey_filter_value": survey_filter_value,
+            "survey_filter_label": survey_filter_label,
+            "trend_dates": trend_dates,
+            "trend_scores": trend_scores,
+            "department_scores": dept_scores,
+            "division_scores": div_scores,
+        }
+        yield record
+
+
 class WhosOut(TapBambooHRStream):
     name = "whos_out"
     path = "/time_off/whos_out"

--- a/tap_bamboohr/streams.py
+++ b/tap_bamboohr/streams.py
@@ -475,18 +475,19 @@ class JobInfo(TapBambooHRStream):
                 yield row
 
 
-class ENPS(TapBambooHRStream):
-    """Employee Net Promoter Score report stream.
+class ENPSSurveys(TapBambooHRStream):
+    """Discovers available eNPS survey periods.
 
     Uses the subdomain-based URL (not the API gateway).
-    Extracts key eNPS metrics from the widget-based report response.
+    Makes a single request to discover all survey period IDs, which are then
+    used by the child ENPS stream to fetch each period's data.
     """
 
-    name = "enps"
+    name = "enps_surveys"
     path = "/reports/enps/-49"
-    primary_keys = ["report_id", "survey_filter_value"]
+    primary_keys = ["survey_id"]
     replication_key = None
-    schema_filepath = SCHEMAS_DIR / "enps.json"
+    schema_filepath = SCHEMAS_DIR / "enps_surveys.json"
 
     @property
     def url_base(self) -> str:
@@ -497,6 +498,56 @@ class ENPS(TapBambooHRStream):
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         return {"format": "json"}
+
+    def get_new_paginator(self) -> SinglePagePaginator:
+        return SinglePagePaginator()
+
+    def get_child_context(
+        self,
+        record: dict,
+        context: Optional[dict],
+    ) -> dict:
+        return {"survey_id": record["survey_id"]}
+
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:
+        data = response.json()
+        widgets = data.get("formatData", {}).get("widgets", {})
+        survey_filter = widgets.get("surveyFilter", {}).get("data", {})
+        items = survey_filter.get("selectData", {}).get("items", [])
+        for item in items:
+            if "value" in item:
+                yield {
+                    "survey_id": item["value"],
+                    "survey_label": item.get("displayText"),
+                }
+
+
+class ENPS(TapBambooHRStream):
+    """Employee Net Promoter Score report stream.
+
+    Uses the subdomain-based URL (not the API gateway).
+    Child of ENPSSurveys — fetches eNPS data for each historical survey period.
+    """
+
+    name = "enps"
+    path = "/reports/enps/-49"
+    primary_keys = ["report_id", "survey_filter_value"]
+    replication_key = None
+    schema_filepath = SCHEMAS_DIR / "enps.json"
+    parent_stream_type = ENPSSurveys
+
+    @property
+    def url_base(self) -> str:
+        subdomain = self.config.get("subdomain")
+        return f"https://{subdomain}.bamboohr.com"
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        params = {"format": "json"}
+        if context and context.get("survey_id"):
+            params["surveyFilter"] = context["survey_id"]
+        return params
 
     def get_new_paginator(self) -> SinglePagePaginator:
         return SinglePagePaginator()

--- a/tap_bamboohr/tap.py
+++ b/tap_bamboohr/tap.py
@@ -22,6 +22,7 @@ from tap_bamboohr.streams import (
     LocationsDetail,
     WhosOut,
     TimeOffRequests,
+    Jobs,
 )
 
 PLUGIN_NAME = "tap-bamboohr"
@@ -41,6 +42,7 @@ STREAM_TYPES = [  # CustomReport has special handing below
     LocationsDetail,
     WhosOut,
     TimeOffRequests,
+    Jobs,
 ]
 
 

--- a/tap_bamboohr/tap.py
+++ b/tap_bamboohr/tap.py
@@ -9,6 +9,7 @@ from singer_sdk import typing as th
 from tap_bamboohr.streams import (
     CustomReport,
     ENPS,
+    ENPSSurveys,
     Photos,
     PhotosUsers,
     Employees,
@@ -30,6 +31,7 @@ PLUGIN_NAME = "tap-bamboohr"
 
 STREAM_TYPES = [  # CustomReport has special handing below
     ENPS,
+    ENPSSurveys,
     Photos,
     PhotosUsers,
     Employees,

--- a/tap_bamboohr/tap.py
+++ b/tap_bamboohr/tap.py
@@ -8,6 +8,7 @@ from singer_sdk import typing as th
 
 from tap_bamboohr.streams import (
     CustomReport,
+    ENPS,
     Photos,
     PhotosUsers,
     Employees,
@@ -28,6 +29,7 @@ from tap_bamboohr.streams import (
 PLUGIN_NAME = "tap-bamboohr"
 
 STREAM_TYPES = [  # CustomReport has special handing below
+    ENPS,
     Photos,
     PhotosUsers,
     Employees,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new streams that hit different BambooHR endpoints and rely on parsing nested widget JSON, which could be brittle if the report response shape changes.
> 
> **Overview**
> Adds two new report-based streams for BambooHR eNPS: `enps_surveys` discovers available survey periods, and child stream `enps` fetches the eNPS report for each period using the subdomain (non-gateway) URL and flattens key metrics plus trend/department/division breakdowns into a single record.
> 
> Adds a new `jobs` stream to pull applicant tracking jobs (all status groups) and registers `enps`, `enps_surveys`, and `jobs` in `tap.py`. Also updates `.gitignore` to exclude `.idea/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad19573a5f681b18a4d47ff7a9329b18fbd16d1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->