### PR TITLE
Fix/image validation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -746,6 +746,85 @@ python-dateutil = ">=2.6,<3.0"
 pytzdata = ">=2020.1"
 
 [[package]]
+name = "pillow"
+version = "9.5.0"
+description = "Python Imaging Library (Fork)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "Pillow-9.5.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:ace6ca218308447b9077c14ea4ef381ba0b67ee78d64046b3f19cf4e1139ad16"},
+    {file = "Pillow-9.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d3d403753c9d5adc04d4694d35cf0391f0f3d57c8e0030aac09d7678fa8030aa"},
+    {file = "Pillow-9.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ba1b81ee69573fe7124881762bb4cd2e4b6ed9dd28c9c60a632902fe8db8b38"},
+    {file = "Pillow-9.5.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fe7e1c262d3392afcf5071df9afa574544f28eac825284596ac6db56e6d11062"},
+    {file = "Pillow-9.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f36397bf3f7d7c6a3abdea815ecf6fd14e7fcd4418ab24bae01008d8d8ca15e"},
+    {file = "Pillow-9.5.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:252a03f1bdddce077eff2354c3861bf437c892fb1832f75ce813ee94347aa9b5"},
+    {file = "Pillow-9.5.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:85ec677246533e27770b0de5cf0f9d6e4ec0c212a1f89dfc941b64b21226009d"},
+    {file = "Pillow-9.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b416f03d37d27290cb93597335a2f85ed446731200705b22bb927405320de903"},
+    {file = "Pillow-9.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1781a624c229cb35a2ac31cc4a77e28cafc8900733a864870c49bfeedacd106a"},
+    {file = "Pillow-9.5.0-cp310-cp310-win32.whl", hash = "sha256:8507eda3cd0608a1f94f58c64817e83ec12fa93a9436938b191b80d9e4c0fc44"},
+    {file = "Pillow-9.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:d3c6b54e304c60c4181da1c9dadf83e4a54fd266a99c70ba646a9baa626819eb"},
+    {file = "Pillow-9.5.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:7ec6f6ce99dab90b52da21cf0dc519e21095e332ff3b399a357c187b1a5eee32"},
+    {file = "Pillow-9.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:560737e70cb9c6255d6dcba3de6578a9e2ec4b573659943a5e7e4af13f298f5c"},
+    {file = "Pillow-9.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96e88745a55b88a7c64fa49bceff363a1a27d9a64e04019c2281049444a571e3"},
+    {file = "Pillow-9.5.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d9c206c29b46cfd343ea7cdfe1232443072bbb270d6a46f59c259460db76779a"},
+    {file = "Pillow-9.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cfcc2c53c06f2ccb8976fb5c71d448bdd0a07d26d8e07e321c103416444c7ad1"},
+    {file = "Pillow-9.5.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a0f9bb6c80e6efcde93ffc51256d5cfb2155ff8f78292f074f60f9e70b942d99"},
+    {file = "Pillow-9.5.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8d935f924bbab8f0a9a28404422da8af4904e36d5c33fc6f677e4c4485515625"},
+    {file = "Pillow-9.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fed1e1cf6a42577953abbe8e6cf2fe2f566daebde7c34724ec8803c4c0cda579"},
+    {file = "Pillow-9.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c1170d6b195555644f0616fd6ed929dfcf6333b8675fcca044ae5ab110ded296"},
+    {file = "Pillow-9.5.0-cp311-cp311-win32.whl", hash = "sha256:54f7102ad31a3de5666827526e248c3530b3a33539dbda27c6843d19d72644ec"},
+    {file = "Pillow-9.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:cfa4561277f677ecf651e2b22dc43e8f5368b74a25a8f7d1d4a3a243e573f2d4"},
+    {file = "Pillow-9.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:965e4a05ef364e7b973dd17fc765f42233415974d773e82144c9bbaaaea5d089"},
+    {file = "Pillow-9.5.0-cp312-cp312-win32.whl", hash = "sha256:22baf0c3cf0c7f26e82d6e1adf118027afb325e703922c8dfc1d5d0156bb2eeb"},
+    {file = "Pillow-9.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:432b975c009cf649420615388561c0ce7cc31ce9b2e374db659ee4f7d57a1f8b"},
+    {file = "Pillow-9.5.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:5d4ebf8e1db4441a55c509c4baa7a0587a0210f7cd25fcfe74dbbce7a4bd1906"},
+    {file = "Pillow-9.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:375f6e5ee9620a271acb6820b3d1e94ffa8e741c0601db4c0c4d3cb0a9c224bf"},
+    {file = "Pillow-9.5.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:99eb6cafb6ba90e436684e08dad8be1637efb71c4f2180ee6b8f940739406e78"},
+    {file = "Pillow-9.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2dfaaf10b6172697b9bceb9a3bd7b951819d1ca339a5ef294d1f1ac6d7f63270"},
+    {file = "Pillow-9.5.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:763782b2e03e45e2c77d7779875f4432e25121ef002a41829d8868700d119392"},
+    {file = "Pillow-9.5.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:35f6e77122a0c0762268216315bf239cf52b88865bba522999dc38f1c52b9b47"},
+    {file = "Pillow-9.5.0-cp37-cp37m-win32.whl", hash = "sha256:aca1c196f407ec7cf04dcbb15d19a43c507a81f7ffc45b690899d6a76ac9fda7"},
+    {file = "Pillow-9.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:322724c0032af6692456cd6ed554bb85f8149214d97398bb80613b04e33769f6"},
+    {file = "Pillow-9.5.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:a0aa9417994d91301056f3d0038af1199eb7adc86e646a36b9e050b06f526597"},
+    {file = "Pillow-9.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8286396b351785801a976b1e85ea88e937712ee2c3ac653710a4a57a8da5d9c"},
+    {file = "Pillow-9.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c830a02caeb789633863b466b9de10c015bded434deb3ec87c768e53752ad22a"},
+    {file = "Pillow-9.5.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fbd359831c1657d69bb81f0db962905ee05e5e9451913b18b831febfe0519082"},
+    {file = "Pillow-9.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8fc330c3370a81bbf3f88557097d1ea26cd8b019d6433aa59f71195f5ddebbf"},
+    {file = "Pillow-9.5.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:7002d0797a3e4193c7cdee3198d7c14f92c0836d6b4a3f3046a64bd1ce8df2bf"},
+    {file = "Pillow-9.5.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:229e2c79c00e85989a34b5981a2b67aa079fd08c903f0aaead522a1d68d79e51"},
+    {file = "Pillow-9.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9adf58f5d64e474bed00d69bcd86ec4bcaa4123bfa70a65ce72e424bfb88ed96"},
+    {file = "Pillow-9.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:662da1f3f89a302cc22faa9f14a262c2e3951f9dbc9617609a47521c69dd9f8f"},
+    {file = "Pillow-9.5.0-cp38-cp38-win32.whl", hash = "sha256:6608ff3bf781eee0cd14d0901a2b9cc3d3834516532e3bd673a0a204dc8615fc"},
+    {file = "Pillow-9.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:e49eb4e95ff6fd7c0c402508894b1ef0e01b99a44320ba7d8ecbabefddcc5569"},
+    {file = "Pillow-9.5.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:482877592e927fd263028c105b36272398e3e1be3269efda09f6ba21fd83ec66"},
+    {file = "Pillow-9.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3ded42b9ad70e5f1754fb7c2e2d6465a9c842e41d178f262e08b8c85ed8a1d8e"},
+    {file = "Pillow-9.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c446d2245ba29820d405315083d55299a796695d747efceb5717a8b450324115"},
+    {file = "Pillow-9.5.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aca1152d93dcc27dc55395604dcfc55bed5f25ef4c98716a928bacba90d33a3"},
+    {file = "Pillow-9.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:608488bdcbdb4ba7837461442b90ea6f3079397ddc968c31265c1e056964f1ef"},
+    {file = "Pillow-9.5.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:60037a8db8750e474af7ffc9faa9b5859e6c6d0a50e55c45576bf28be7419705"},
+    {file = "Pillow-9.5.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:07999f5834bdc404c442146942a2ecadd1cb6292f5229f4ed3b31e0a108746b1"},
+    {file = "Pillow-9.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a127ae76092974abfbfa38ca2d12cbeddcdeac0fb71f9627cc1135bedaf9d51a"},
+    {file = "Pillow-9.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:489f8389261e5ed43ac8ff7b453162af39c3e8abd730af8363587ba64bb2e865"},
+    {file = "Pillow-9.5.0-cp39-cp39-win32.whl", hash = "sha256:9b1af95c3a967bf1da94f253e56b6286b50af23392a886720f563c547e48e964"},
+    {file = "Pillow-9.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:77165c4a5e7d5a284f10a6efaa39a0ae8ba839da344f20b111d62cc932fa4e5d"},
+    {file = "Pillow-9.5.0-pp38-pypy38_pp73-macosx_10_10_x86_64.whl", hash = "sha256:833b86a98e0ede388fa29363159c9b1a294b0905b5128baf01db683672f230f5"},
+    {file = "Pillow-9.5.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aaf305d6d40bd9632198c766fb64f0c1a83ca5b667f16c1e79e1661ab5060140"},
+    {file = "Pillow-9.5.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0852ddb76d85f127c135b6dd1f0bb88dbb9ee990d2cd9aa9e28526c93e794fba"},
+    {file = "Pillow-9.5.0-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:91ec6fe47b5eb5a9968c79ad9ed78c342b1f97a091677ba0e012701add857829"},
+    {file = "Pillow-9.5.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:cb841572862f629b99725ebaec3287fc6d275be9b14443ea746c1dd325053cbd"},
+    {file = "Pillow-9.5.0-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:c380b27d041209b849ed246b111b7c166ba36d7933ec6e41175fd15ab9eb1572"},
+    {file = "Pillow-9.5.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c9af5a3b406a50e313467e3565fc99929717f780164fe6fbb7704edba0cebbe"},
+    {file = "Pillow-9.5.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5671583eab84af046a397d6d0ba25343c00cd50bce03787948e0fff01d4fd9b1"},
+    {file = "Pillow-9.5.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:84a6f19ce086c1bf894644b43cd129702f781ba5751ca8572f08aa40ef0ab7b7"},
+    {file = "Pillow-9.5.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:1e7723bd90ef94eda669a3c2c19d549874dd5badaeefabefd26053304abe5799"},
+    {file = "Pillow-9.5.0.tar.gz", hash = "sha256:bf548479d336726d7a0eceb6e767e179fbde37833ae42794602631a070d630f1"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-inline-tabs", "sphinx-removed-in", "sphinxext-opengraph"]
+tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
+
+[[package]]
 name = "pkgutil-resolve-name"
 version = "1.3.10"
 description = "Resolve a name to an object."
@@ -1544,5 +1623,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = "<3.11,>=3.7.1"
-content-hash = "42b42372dfbb4a43236fd00f5a9cc9ad96e90bae5d764ffd77f0a75db538c23f"
+python-versions = ">=3.7.1,<3.12"
+content-hash = "1c5a6b4fbc52c91fd7f84680043b6659c2be430bc5690667080d682ac1032ec5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ authors = ["Derek Visch <dvisch@autoidm.com>"]
 license = "Apache v2"
 
 [tool.poetry.dependencies]
-python = ">=3.7.1"
+python = ">=3.7.1,<3.12"
 requests = "^2.25.1"
+pillow = ">=9.5.0,<10"
 singer-sdk = "0.29.0"
 setuptools = "<81"
 

--- a/tap_bamboohr/schemas/locations.json
+++ b/tap_bamboohr/schemas/locations.json
@@ -4,6 +4,80 @@
         "id": {
             "type": ["string","null"]
         },
+
+        "label": {
+            "type": ["string","null"]
+        },
+        "archived": {
+            "type": ["boolean","null"]
+        },
+        "archivedAt": {
+            "type": ["string","null"]
+        },
+        "createdAt": {
+            "type": ["string","null"]
+        },
+        "manageable": {
+            "type": ["boolean","null"]
+        },
+        "address": {
+            "type": ["object","null"],
+            "properties": {
+                "address1": {
+                    "type": ["string","null"]
+                },
+                "address2": {
+                    "type": ["string","null"]
+                },
+                "city": {
+                    "type": ["string","null"]
+                },
+                "stateId": {
+                    "type": ["string","null"]
+                },
+                "countryId": {
+                    "type": ["string","null"]
+                },
+                "zipcode": {
+                    "type": ["string","null"]
+                },
+                "timezone": {
+                    "type": ["string","null"]
+                },
+                "remoteLocation": {
+                    "type": ["boolean","null"]
+                },
+                "state": {
+                    "type": ["object","null"],
+                    "properties": {
+                        "id": {
+                            "type": ["string","null"]
+                        },
+                        "name": {
+                            "type": ["string","null"]
+                        },
+                        "abbreviation": {
+                            "type": ["string","null"]
+                        }
+                    }
+                },
+                "country": {
+                    "type": ["object","null"],
+                    "properties": {
+                        "id": {
+                            "type": ["string","null"]
+                        },
+                        "name": {
+                            "type": ["string","null"]
+                        },
+                        "isoCode": {
+                            "type": ["string","null"]
+                        }
+                    }
+                }
+            }
+        },
+
         "name": {
             "type": ["string","null"]
         },
@@ -55,6 +129,9 @@
         },
         "phone": {
             "type": ["string","null"]
+        },
+        "remoteLocation": {
+            "type": ["boolean","null"]
         }
     }
 }

--- a/tap_bamboohr/streams.py
+++ b/tap_bamboohr/streams.py
@@ -503,7 +503,7 @@ class Photos(TapBambooHRStream):
         try:
             with Image.open(BytesIO(content)) as image:
                 image.verify()
-        except (UnidentifiedImageError, OSError, ValueError):
+        except (UnidentifiedImageError, OSError, ValueError, SyntaxError):
             return False
         return True
 

--- a/tap_bamboohr/streams.py
+++ b/tap_bamboohr/streams.py
@@ -14,6 +14,7 @@ import requests
 from singer_sdk import typing
 from singer_sdk._singerlib import Schema
 from singer_sdk.authenticators import BasicAuthenticator
+from singer_sdk.exceptions import FatalAPIError
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.pagination import BasePageNumberPaginator, SinglePagePaginator
 from singer_sdk.streams.rest import RESTStream
@@ -473,9 +474,44 @@ class Photos(TapBambooHRStream):
             self.logger.warning(f"No photo found for employee, skipping {context.get('_sdc_id')}")
             pass
 
+    IMAGE_SIGNATURES = (
+        b"\xff\xd8\xff",          # JPEG
+        b"\x89PNG\r\n\x1a\n",     # PNG
+        b"GIF87a",
+        b"GIF89a",
+        b"BM",                    # BMP
+        b"RIFF",                  # WEBP container
+    )
+
+    @property
+    def http_headers(self) -> dict:
+        # The parent stream sets Accept: application/json, which makes BambooHR
+        # return a {mimeType, fileBase64} JSON envelope instead of raw image
+        # bytes. Request raw bytes here.
+        headers = super().http_headers
+        headers["Accept"] = "image/*"
+        return headers
+
+    @staticmethod
+    def _try_parse_envelope(response: requests.Response) -> Optional[dict]:
+        """Return the response body as a {mimeType, fileBase64} dict, or None if it is not one."""
+        if response.content[:1] != b"{":
+            return None
+        try:
+            envelope = response.json()
+        except ValueError:
+            return None
+        if isinstance(envelope, dict) and "fileBase64" in envelope:
+            return envelope
+        return None
+
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        yield {"photo": base64.b64encode(response.content).decode("utf-8")}
-    
+        envelope = self._try_parse_envelope(response)
+        if envelope is not None:
+            yield {"photo": envelope["fileBase64"]}
+        else:
+            yield {"photo": base64.b64encode(response.content).decode("utf-8")}
+
     class NoPhotoFound(Exception):
         pass
 
@@ -483,6 +519,21 @@ class Photos(TapBambooHRStream):
         if response.status_code == HTTPStatus.NOT_FOUND:
             raise self.NoPhotoFound()
         super().validate_response(response)
+        # Accept raw image bytes or the {mimeType, fileBase64} envelope. Reject
+        # anything else (e.g. HTML or XML error pages) so we don't store a
+        # non-image value that targets will fail on later.
+        content = response.content
+        if any(content.startswith(sig) for sig in self.IMAGE_SIGNATURES):
+            return
+        if self._try_parse_envelope(response) is not None:
+            return
+        content_type = response.headers.get("Content-Type", "")
+        preview = content[:80].decode("utf-8", errors="replace")
+        preview = preview.replace("\r", " ").replace("\n", " ").strip()
+        raise FatalAPIError(
+            "Photo endpoint returned unrecognized content. "
+            f"Content-Type: {content_type!r}. Preview: {preview!r}"
+        )
 
 
 # A more generic tables stream would be better, there is a table metadata api

--- a/tap_bamboohr/streams.py
+++ b/tap_bamboohr/streams.py
@@ -7,10 +7,12 @@ import json
 import typing as t
 from functools import cached_property
 from http import HTTPStatus
+from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
 import requests
+from PIL import Image, UnidentifiedImageError
 from singer_sdk import typing
 from singer_sdk._singerlib import Schema
 from singer_sdk.authenticators import BasicAuthenticator
@@ -474,15 +476,6 @@ class Photos(TapBambooHRStream):
             self.logger.warning(f"No photo found for employee, skipping {context.get('_sdc_id')}")
             pass
 
-    IMAGE_SIGNATURES = (
-        b"\xff\xd8\xff",          # JPEG
-        b"\x89PNG\r\n\x1a\n",     # PNG
-        b"GIF87a",
-        b"GIF89a",
-        b"BM",                    # BMP
-        b"RIFF",                  # WEBP container
-    )
-
     @property
     def http_headers(self) -> dict:
         # The parent stream sets Accept: application/json, which makes BambooHR
@@ -505,6 +498,15 @@ class Photos(TapBambooHRStream):
             return envelope
         return None
 
+    @staticmethod
+    def _is_valid_image(content: bytes) -> bool:
+        try:
+            with Image.open(BytesIO(content)) as image:
+                image.verify()
+        except (UnidentifiedImageError, OSError, ValueError):
+            return False
+        return True
+
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         envelope = self._try_parse_envelope(response)
         if envelope is not None:
@@ -523,7 +525,7 @@ class Photos(TapBambooHRStream):
         # anything else (e.g. HTML or XML error pages) so we don't store a
         # non-image value that targets will fail on later.
         content = response.content
-        if any(content.startswith(sig) for sig in self.IMAGE_SIGNATURES):
+        if self._is_valid_image(content):
             return
         if self._try_parse_envelope(response) is not None:
             return

--- a/tap_bamboohr/streams.py
+++ b/tap_bamboohr/streams.py
@@ -15,7 +15,7 @@ from singer_sdk import typing
 from singer_sdk._singerlib import Schema
 from singer_sdk.authenticators import BasicAuthenticator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
-from singer_sdk.pagination import SinglePagePaginator
+from singer_sdk.pagination import BasePageNumberPaginator, SinglePagePaginator
 from singer_sdk.streams.rest import RESTStream
 from singer_sdk.tap_base import Tap
 
@@ -141,13 +141,105 @@ class Employees(TapBambooHRStream):
     schema_filepath = SCHEMAS_DIR / "directory.json"
 
 
+class _HrisLocationsPaginator(BasePageNumberPaginator):
+    # /hris/org/locations response.meta: {page, pageSize, totalPages, totalItems}.
+    #
+    # The public docs say the `page` query param "defaults to 0", implying
+    # 0-indexed pagination. That is misleading — empirically (verified on a
+    # live tenant) the endpoint is 1-indexed: page=0 returns HTTP 422, page=1
+    # returns the first record, and omitting the param is equivalent to page=1.
+    # So start_value=1 and `meta.page < meta.totalPages` are both correct.
+    # A defensive bonus: overshooting the last page returns HTTP 200 with an
+    # empty data array and meta.totalPages=0, so this condition halts cleanly
+    # even if BambooHR ever changes indexing or sizing.
+    def has_more(self, response: requests.Response) -> bool:
+        meta = (response.json() or {}).get("meta") or {}
+        return meta.get("page", 0) < meta.get("totalPages", 0)
+
+
 class LocationsDetail(TapBambooHRStream):
+    # Sources from /hris/org/locations (not /applicant_tracking/locations) because
+    # the HRIS endpoint returns remote locations and exposes address.remoteLocation.
+    #
+    # Record shape: the full HRIS response is passed through verbatim (label,
+    # archived, archivedAt, createdAt, manageable, address{...with expanded
+    # state/country}) so future HRIS fields — including new sub-fields BambooHR
+    # may add under address, state, or country — do not get silently dropped.
+    # Flat aliases (name, city, zipcode, addressLine1, addressLine2, state.abbrev,
+    # country.iso_code, phone, remoteLocation, description) are derived and added
+    # on top so existing consumers that read the old ATS shape keep working.
+    # Archived locations are filtered to match the ATS endpoint's historical
+    # behavior.
+    #
+    # UPGRADE NOTE (next major): drop the flat aliases from _build_record and
+    # locations.json. They exist only to avoid a breaking change for consumers
+    # that were wired up against the /applicant_tracking/locations shape. Once
+    # all downstream consumers have been cut over to read label / address.* /
+    # address.state.abbreviation directly, remove:
+    #   - the record.update({...}) block in _build_record
+    #   - the corresponding top-level properties in schemas/locations.json
+    #     (name, description, city, state, country, zipcode, addressLine1,
+    #      addressLine2, phone, remoteLocation)
+    # Leave the schema's address.remoteLocation in place; that's the HRIS-native
+    # field and not an alias.
     name = "locationdetails"
-    path = "/applicant_tracking/locations"
+    path = "/hris/org/locations"
     primary_keys = ["id"]
-    records_jsonpath = "$[*]"
+    records_jsonpath = "$.data[*]"
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "locations.json"
+
+    def get_new_paginator(self) -> BasePageNumberPaginator:
+        return _HrisLocationsPaginator(start_value=1)
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"expand": "state,country"}
+        if next_page_token is not None:
+            params["page"] = next_page_token
+        return params
+
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:
+        for row in extract_jsonpath(self.records_jsonpath, response.json()):
+            record = self._build_record(row)
+            if record is None:
+                continue
+            yield self.standardize_data(record)
+
+    @staticmethod
+    def _build_record(row: dict) -> Optional[dict]:
+        if row.get("archived"):
+            return None
+        address = row.get("address") or {}
+        state_src = address.get("state") or {}
+        country_src = address.get("country") or {}
+        record = dict(row)  # preserve full HRIS shape verbatim
+        record.update(
+            {
+                # Backwards-compatible flat aliases for existing consumers.
+                "name": row.get("label"),
+                "description": None,
+                "city": address.get("city"),
+                "state": {
+                    "id": state_src.get("id"),
+                    "name": state_src.get("name"),
+                    "abbrev": state_src.get("abbreviation"),
+                    "iso_code": None,
+                },
+                "country": {
+                    "id": country_src.get("id"),
+                    "name": country_src.get("name"),
+                    "iso_code": country_src.get("isoCode"),
+                },
+                "zipcode": address.get("zipcode"),
+                "addressLine1": address.get("address1"),
+                "addressLine2": address.get("address2"),
+                "phone": None,
+                "remoteLocation": address.get("remoteLocation"),
+            }
+        )
+        return record
 
 
 class CustomReport(TapBambooHRStream):

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -121,6 +121,18 @@ def test_validate_response_rejects_signature_only_payload() -> None:
         stream.validate_response(make_response(content=FAKE_JPEG))
 
 
+def test_validate_response_rejects_png_with_corrupt_chunk() -> None:
+    # Pillow's verify() raises SyntaxError (not UnidentifiedImageError) when a
+    # PNG opens cleanly but has a bad chunk checksum. Make sure we still reject.
+    stream = make_stream()
+    corrupt = bytearray(RAW_PNG)
+    corrupt[len(corrupt) // 2] ^= 0xFF
+    with pytest.raises(FatalAPIError):
+        stream.validate_response(
+            make_response(content=bytes(corrupt), content_type="image/png")
+        )
+
+
 def test_validate_response_raises_no_photo_found_on_404() -> None:
     stream = make_stream()
     response = make_response(

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import base64
 import json
+from io import BytesIO
 
 import pytest
 import requests
+from PIL import Image
 from singer_sdk.exceptions import FatalAPIError
 
 from tap_bamboohr.streams import Photos
@@ -20,8 +22,18 @@ from tap_bamboohr.tap import TapBambooHR
 PHOTO_URL = (
     "https://api.bamboohr.com/api/gateway.php/example/v1/employees/123/photo/large"
 )
-RAW_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01fake-jpeg-bytes"
-RAW_PNG = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+
+
+def make_image_bytes(image_format: str) -> bytes:
+    image = Image.new("RGB", (1, 1), color=(255, 255, 255))
+    buffer = BytesIO()
+    image.save(buffer, format=image_format)
+    return buffer.getvalue()
+
+
+RAW_JPEG = make_image_bytes("JPEG")
+RAW_PNG = make_image_bytes("PNG")
+FAKE_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01fake-jpeg-bytes"
 
 
 def make_stream() -> Photos:
@@ -101,6 +113,12 @@ def test_validate_response_rejects_html_error_page() -> None:
     )
     with pytest.raises(FatalAPIError):
         stream.validate_response(response)
+
+
+def test_validate_response_rejects_signature_only_payload() -> None:
+    stream = make_stream()
+    with pytest.raises(FatalAPIError):
+        stream.validate_response(make_response(content=FAKE_JPEG))
 
 
 def test_validate_response_raises_no_photo_found_on_404() -> None:

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -1,0 +1,206 @@
+"""Tests for the Photos stream.
+
+The endpoint returns raw image bytes by default and a
+{mimeType, fileBase64} JSON envelope when Accept: application/json is sent.
+The stream handles both and rejects anything else.
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+import requests
+from singer_sdk.exceptions import FatalAPIError
+
+from tap_bamboohr.streams import Photos
+from tap_bamboohr.tap import TapBambooHR
+
+
+PHOTO_URL = (
+    "https://api.bamboohr.com/api/gateway.php/example/v1/employees/123/photo/large"
+)
+RAW_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01fake-jpeg-bytes"
+RAW_PNG = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+
+
+def make_stream() -> Photos:
+    tap = TapBambooHR(
+        config={
+            "auth_token": "token",
+            "subdomain": "example",
+            "field_mismatch": "ignore",
+            "photo_size": "large",
+        }
+    )
+    return Photos(tap=tap)
+
+
+def make_response(
+    *,
+    status_code: int = 200,
+    content: bytes,
+    content_type: str = "image/jpeg",
+    reason: str = "OK",
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = content
+    response.headers["Content-Type"] = content_type
+    response.reason = reason
+    response.url = PHOTO_URL
+    return response
+
+
+# ---------- validate_response ------------------------------------------------
+
+
+def test_validate_response_accepts_raw_jpeg() -> None:
+    stream = make_stream()
+    stream.validate_response(make_response(content=RAW_JPEG))
+
+
+def test_validate_response_accepts_raw_png() -> None:
+    stream = make_stream()
+    stream.validate_response(
+        make_response(content=RAW_PNG, content_type="image/png")
+    )
+
+
+def test_validate_response_accepts_json_envelope() -> None:
+    stream = make_stream()
+    envelope = {
+        "mimeType": "image/jpeg",
+        "fileBase64": base64.b64encode(RAW_JPEG).decode("ascii"),
+    }
+    response = make_response(
+        content=json.dumps(envelope).encode("utf-8"),
+        content_type="application/json",
+    )
+    stream.validate_response(response)
+
+
+def test_validate_response_rejects_xml_error_payload() -> None:
+    stream = make_stream()
+    response = make_response(
+        content=(
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b"<Error><Code>InvalidKey</Code></Error>"
+        ),
+        content_type="application/xml",
+    )
+    with pytest.raises(FatalAPIError):
+        stream.validate_response(response)
+
+
+def test_validate_response_rejects_html_error_page() -> None:
+    stream = make_stream()
+    response = make_response(
+        content=b"<!doctype html><html><body>Maintenance</body></html>",
+        content_type="text/html",
+    )
+    with pytest.raises(FatalAPIError):
+        stream.validate_response(response)
+
+
+def test_validate_response_raises_no_photo_found_on_404() -> None:
+    stream = make_stream()
+    response = make_response(
+        status_code=404,
+        content=b"",
+        content_type="application/json",
+        reason="Not Found",
+    )
+    with pytest.raises(stream.NoPhotoFound):
+        stream.validate_response(response)
+
+
+# ---------- parse_response ---------------------------------------------------
+
+
+def test_parse_response_raw_bytes_yields_base64() -> None:
+    stream = make_stream()
+    records = list(stream.parse_response(make_response(content=RAW_JPEG)))
+    assert len(records) == 1
+    assert records[0]["photo"] == base64.b64encode(RAW_JPEG).decode("ascii")
+
+
+def test_parse_response_json_envelope_yields_inner_filebase64() -> None:
+    stream = make_stream()
+    inner_b64 = base64.b64encode(RAW_JPEG).decode("ascii")
+    envelope = {"mimeType": "image/jpeg", "fileBase64": inner_b64}
+    response = make_response(
+        content=json.dumps(envelope).encode("utf-8"),
+        content_type="application/json",
+    )
+    records = list(stream.parse_response(response))
+    assert len(records) == 1
+    # The yielded value must decode back to the raw image, not the envelope.
+    assert base64.b64decode(records[0]["photo"]) == RAW_JPEG
+
+
+def test_parse_response_png_envelope_round_trip() -> None:
+    stream = make_stream()
+    inner_b64 = base64.b64encode(RAW_PNG).decode("ascii")
+    envelope = {"mimeType": "image/png", "fileBase64": inner_b64}
+    response = make_response(
+        content=json.dumps(envelope).encode("utf-8"),
+        content_type="application/json",
+    )
+    records = list(stream.parse_response(response))
+    assert base64.b64decode(records[0]["photo"]) == RAW_PNG
+
+
+def test_parse_response_malformed_json_falls_back_to_raw_encoding() -> None:
+    # Content that starts with `{` but is not valid JSON must not be unwrapped.
+    # validate_response rejects it on a real request; parse_response must still
+    # return a deterministic value rather than raise.
+    stream = make_stream()
+    payload = b'{"not-json'
+    records = list(stream.parse_response(make_response(content=payload)))
+    assert records[0]["photo"] == base64.b64encode(payload).decode("ascii")
+
+
+def test_parse_response_json_without_filebase64_treated_as_non_envelope() -> None:
+    stream = make_stream()
+    payload = json.dumps({"mimeType": "image/jpeg"}).encode("utf-8")
+    records = list(stream.parse_response(make_response(content=payload)))
+    assert records[0]["photo"] == base64.b64encode(payload).decode("ascii")
+
+
+# ---------- Accept header ----------------------------------------------------
+
+
+def test_http_headers_request_binary_image_response() -> None:
+    stream = make_stream()
+    assert stream.http_headers["Accept"] == "image/*"
+
+
+# ---------- envelope helper --------------------------------------------------
+
+
+def test_try_parse_envelope_returns_none_for_raw_image() -> None:
+    stream = make_stream()
+    assert stream._try_parse_envelope(make_response(content=RAW_JPEG)) is None
+
+
+def test_try_parse_envelope_returns_none_for_json_missing_filebase64() -> None:
+    stream = make_stream()
+    response = make_response(
+        content=json.dumps({"mimeType": "image/jpeg"}).encode("utf-8"),
+        content_type="application/json",
+    )
+    assert stream._try_parse_envelope(response) is None
+
+
+def test_try_parse_envelope_returns_envelope_dict_when_valid() -> None:
+    stream = make_stream()
+    inner_b64 = base64.b64encode(RAW_JPEG).decode("ascii")
+    response = make_response(
+        content=json.dumps(
+            {"mimeType": "image/jpeg", "fileBase64": inner_b64}
+        ).encode("utf-8"),
+        content_type="application/json",
+    )
+    envelope = stream._try_parse_envelope(response)
+    assert envelope == {"mimeType": "image/jpeg", "fileBase64": inner_b64}


### PR DESCRIPTION
* Switch locationdetails to /hris/org/locations. The legacy endpoint is being deprecated; the new one returns a richer payload and exposes remoteLocation. Schema updated to match.
* Handle BambooHR photo JSON envelope.  /photo/{size} sometimes returns a {mimeType, fileBase64} JSON wrapper instead of raw image bytes. Photos stream now detects and unwraps the envelope and yields the inner base64 either way.
* Validate photo payloads with Pillow.  Corrupt images are rejected rather than passed to the target.